### PR TITLE
Fix GitHub repo regex match

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,7 +65,7 @@ func LoadConfig() (config Config) {
 	}
 	regexpURL := regexp.MustCompile(`git@([^:]+):([^/]+)/(.+)(\.git)?`)
 	matches := regexpURL.FindStringSubmatch(out)
-	if len(matches) != 4 {
+	if matches == nil {
 		exitf("failed to parse remote url: expect git@<host>:<user>/<repo> (got %q)", out)
 	}
 	config.Host = matches[1]


### PR DESCRIPTION
Previously, running `git pr` threw an error like:
```
failed to parse remote url: expect git@<host>:<user>/<repo> (got "* remote origin
  Fetch URL: git@github.com:myorg/myrepo
  Push  URL: git@github.com:myorg/myrepo
  HEAD branch: main\n  Remote branches:
...
```