### PR TITLE
print err and exit when user.email is not found in git config

### DIFF
--- a/config.go
+++ b/config.go
@@ -129,7 +129,16 @@ Run the following command and choose your github host:
 	}
 	config.User = ghHost.User
 	config.Token = ghHost.OauthToken
-	config.Email = must(getGitConfig("user.email"))
+	email, err := getGitConfig("user.email")
+	if err != nil {
+		fmt.Println("user.email not found in git config")
+		os.Exit(1)
+	}
+	if email == "" {
+		fmt.Println("user.email found in git config, but it's empty")
+		os.Exit(1)
+	}
+	config.Email = email
 	if config.Token == "" { // try getting from keyring
 		key := "gh:" + config.Host
 		config.Token, _ = keyring.Get(key, "")


### PR DESCRIPTION
Avoids this panic when git has not been initialized (e.g. new machine):

![image](https://github.com/user-attachments/assets/dfee29d0-39d1-4e09-9b7c-a8a9b7b0f5de)
