### PR TITLE
feat: add reverse option to config and cli

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	skipDraft     bool     // flag: skip draft commits by default
 	includeDraft  bool     // flag: explicitly include draft commits (highest precedence)
 	draftPatterns []string // wildcard patterns for draft detection (case-insensitive)
+	reverse       bool     // flag/config: show stack in reverse order (newest on top)
 }
 
 type ConfigGit struct {
@@ -90,6 +91,7 @@ func LoadConfig() (config Config) {
 	flag.StringVar(&config.stopAfter, "stop-after", "", "Stop after phase: validate|get-commits|rewrite|push|pr-create")
 	flag.BoolVar(&config.skipDraft, "skip-draft", false, "Skip commits with [draft] in title")
 	flag.BoolVar(&config.includeDraft, "include-draft", false, "Include draft commits (override config)")
+	flag.BoolVar(&config.reverse, "reverse", false, "Show stack in reverse order (newest on top)")
 
 	flagGitHubHosts := flag.String("gh-hosts", "~/.config/gh/hosts.yml", "Path to config.json")
 	flagTimeout := flag.Int("timeout", 20, "API call timeout in seconds")
@@ -150,6 +152,14 @@ func LoadConfig() (config Config) {
 			skipDraftStr, _ := getGitConfig("git-pr.skipDraft")
 			if skipDraftStr == "true" || skipDraftStr == "1" {
 				config.skipDraft = true
+			}
+		}
+
+		// read git config for reverse setting
+		if !config.reverse {
+			reverseStr, _ := getGitConfig("git-pr.reverse")
+			if reverseStr == "true" || reverseStr == "1" {
+				config.reverse = true
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -317,7 +317,17 @@ func generateStackInfo(stackedCommits []*Commit, currentCommit *Commit) string {
 	var stackB strings.Builder
 	sprf := func(msg string, args ...any) { fprintf(&stackB, msg, args...) }
 
-	for _, cm := range stackedCommits {
+	// reverse the stack order if configured (newest on top)
+	commits := stackedCommits
+	if config.reverse {
+		commits = make([]*Commit, len(stackedCommits))
+		copy(commits, stackedCommits)
+		for i, j := 0, len(commits)-1; i < j; i, j = i+1, j-1 {
+			commits[i], commits[j] = commits[j], commits[i]
+		}
+	}
+
+	for _, cm := range commits {
 		var cmRef string
 		cmURL := fmt.Sprintf("https://%v/%v/commit/%v", config.git.host, config.git.repo, cm.ShortHash())
 		switch {


### PR DESCRIPTION
## Add reverse option to display stack in reverse order

### Summary
Adds a new `--reverse` flag and `git-pr.reverse` config option to display the PR stack in the natural stack order, with the newest commits on top, instead of the default oldest-first order.

This is an improvement similar to https://github.com/arxanas/git-branchless/pull/1315.

### Changes
- **Config**: Added `reverse` field to the `Config` struct to control stack display order
- **CLI flag**: Added `--reverse` flag for command-line usage
- **Git config support**: Added support for `git-pr.reverse` config setting (set via `git config git-pr.reverse true`)
- **Stack display**: Modified `generateStackInfo()` to reverse the commit order when enabled

### Usage
```bash
# Via command-line flag
git-pr --reverse

# Via git config (persistent)
git config git-pr.reverse true
```

### Behavior
When enabled, the stack will be displayed with the newest commits at the top, making it easier to see recent changes first. The flag can be set persistently via git config or passed as a CLI argument on each invocation.
